### PR TITLE
Fixed variable filter throwing exception for null variables.

### DIFF
--- a/SpeedrunComSharp/Leaderboards/LeaderboardsClient.cs
+++ b/SpeedrunComSharp/Leaderboards/LeaderboardsClient.cs
@@ -56,9 +56,12 @@ namespace SpeedrunComSharp
             {
                 foreach (var variableValue in variableFilters)
                 {
-                    parameters.Add(string.Format("var-{0}={1}",
+                    if (variableValue != null)
+                    {
+                        parameters.Add(string.Format("var-{0}={1}",
                         Uri.EscapeDataString(variableValue.VariableID),
                         Uri.EscapeDataString(variableValue.ID)));
+                    }
                 }
             }
 


### PR DESCRIPTION
In LiveSplit in the WorldRecord component settings, select the "Filter Leaderboard By Variables" checkbox. Then, in the "Additional Info", select a value for one variable but leave another variable blank. Or leave all of the variables blank. The result will show "Unknown World Record" as an exception was thrown because one of the variables was null. A variable being null should simply mean that the leaderboard should not be filtered by that variable. This change achieves that functionality.