### PR TITLE
Added more null checks to ImageAsset.Parse

### DIFF
--- a/SpeedrunComSharp/Common/ImageAsset.cs
+++ b/SpeedrunComSharp/Common/ImageAsset.cs
@@ -12,7 +12,7 @@ namespace SpeedrunComSharp
 
         public static ImageAsset Parse(SpeedrunComClient client, dynamic imageElement)
         {
-            if (imageElement == null)
+            if (imageElement == null || imageElement.uri == null || imageElement.width == null || imageElement.height == null)
                 return null;
 
             var image = new ImageAsset();


### PR DESCRIPTION
Added extra checks to confirm that the uri, width, and height parameters are available before using them, as this function will currently throw a RuntimeBinder exception in the event of a broken icon (for example: [Fossil Fighters](https://www.speedrun.com/api/v1/games/9dox0mdp) has a broken icon as of writing, so no width or height value is received from the API).

Fixes Issue https://github.com/LiveSplit/SpeedrunComSharp/issues/19