### PR TITLE
Adding omitted fields from new API updates

### DIFF
--- a/SpeedrunComSharp/Common/ImageAsset.cs
+++ b/SpeedrunComSharp/Common/ImageAsset.cs
@@ -5,22 +5,18 @@ namespace SpeedrunComSharp
     public class ImageAsset
     {
         public Uri Uri { get; private set; }
-        public int Width { get; private set; }
-        public int Height { get; private set; }
 
         private ImageAsset() { }
 
         public static ImageAsset Parse(SpeedrunComClient client, dynamic imageElement)
         {
-            if (imageElement == null || imageElement.uri == null || imageElement.width == null || imageElement.height == null)
+            if (imageElement == null || imageElement.uri == null)
                 return null;
 
             var image = new ImageAsset();
 
             var uri = imageElement.uri as string;
             image.Uri = new Uri(uri);
-            image.Width = (int)imageElement.width;
-            image.Height = (int)imageElement.height;
 
             return image;
         }

--- a/SpeedrunComSharp/Games/Game.cs
+++ b/SpeedrunComSharp/Games/Game.cs
@@ -13,8 +13,10 @@ namespace SpeedrunComSharp
         public string ID { get { return Header.ID; } }
         public string Name { get { return Header.Name; } }
         public string JapaneseName { get { return Header.JapaneseName; } }
+        public string TwitchName { get { return Header.TwitchName; } }
         public string Abbreviation { get { return Header.Abbreviation; } }
         public Uri WebLink { get { return Header.WebLink; } }
+        public DateTime? ReleaseDate { get; private set; }
         public int? YearOfRelease { get; private set; }
         public Ruleset Ruleset { get; private set; }
         public bool IsRomHack { get; private set; }
@@ -70,10 +72,15 @@ namespace SpeedrunComSharp
         public static Game Parse(SpeedrunComClient client, dynamic gameElement)
         {
             var game = new Game();
-
+            var gProperties = gameElement.Properties as IDictionary<string, dynamic>;
             //Parse Attributes
 
             game.Header = GameHeader.Parse(client, gameElement);
+
+            var releaseDate = gProperties["release-date"];
+            if (!string.IsNullOrEmpty(releaseDate))
+                game.ReleaseDate = DateTime.Parse(releaseDate, CultureInfo.InvariantCulture, DateTimeStyles.AssumeUniversal);
+
             game.YearOfRelease = gameElement.released;
             game.Ruleset = Ruleset.Parse(client, gameElement.ruleset);
 

--- a/SpeedrunComSharp/Games/GameHeader.cs
+++ b/SpeedrunComSharp/Games/GameHeader.cs
@@ -7,6 +7,7 @@ namespace SpeedrunComSharp
         public string ID { get; private set; }
         public string Name { get; private set; }
         public string JapaneseName { get; private set; }
+        public string TwitchName { get; private set; }
         public string Abbreviation { get; private set; }
         public Uri WebLink { get; private set; }
 
@@ -19,6 +20,7 @@ namespace SpeedrunComSharp
             gameHeader.ID = gameHeaderElement.id as string;
             gameHeader.Name = gameHeaderElement.names.international as string;
             gameHeader.JapaneseName = gameHeaderElement.names.japanese as string;
+            gameHeader.TwitchName = gameHeaderElement.names.twitch as string;
             gameHeader.WebLink = new Uri(gameHeaderElement.weblink as string);
             gameHeader.Abbreviation = gameHeaderElement.abbreviation as string;
 

--- a/SpeedrunComSharp/Users/User.cs
+++ b/SpeedrunComSharp/Users/User.cs
@@ -11,6 +11,7 @@ namespace SpeedrunComSharp
         public string ID { get; private set; }
         public string Name { get; private set; }
         public string JapaneseName { get; private set; }
+        public string[] Pronouns { get; private set; }
         public Uri WebLink { get; private set; }
         public UserNameStyle NameStyle { get; private set; }
         public UserRole Role { get; private set; }
@@ -22,6 +23,9 @@ namespace SpeedrunComSharp
         public Uri YoutubeProfile { get; private set; }
         public Uri TwitterProfile { get; private set; }
         public Uri SpeedRunsLiveProfile { get; private set; }
+
+        public Uri Icon { get; private set; }
+        public Uri Image { get; private set; }
 
         #region Links
 
@@ -69,6 +73,11 @@ namespace SpeedrunComSharp
             user.ID = userElement.id as string;
             user.Name = userElement.names.international as string;
             user.JapaneseName = userElement.names.japanese as string;
+
+            var pronounsTemp = userElement.pronouns as string;
+            if (!string.IsNullOrWhiteSpace(pronounsTemp))
+                user.Pronouns = pronounsTemp.Split(new string[] { ", " }, StringSplitOptions.None);
+
             user.WebLink = new Uri(userElement.weblink as string);
             user.NameStyle = UserNameStyle.Parse(client, properties["name-style"]) as UserNameStyle;
             user.Role = parseUserRole(userElement.role as string);
@@ -98,6 +107,14 @@ namespace SpeedrunComSharp
             var speedRunsLiveLink = userElement.speedrunslive;
             if (speedRunsLiveLink != null)
                 user.SpeedRunsLiveProfile = new Uri(speedRunsLiveLink.uri as string);
+
+            var iconTemp = userElement.assets.icon.uri;
+            if (iconTemp != null)
+                user.Icon = new Uri(iconTemp as string);
+
+            var imageTemp = userElement.assets.image.uri;
+            if (imageTemp != null)
+                user.Image = new Uri(imageTemp as string);
 
             //Parse Links
 


### PR DESCRIPTION
I've added a few changes to the User and Game handlers to use additional values that were added in previous updates to the API. Here's a list of changes made:
* Added user pronouns.
  * Pronouns are stored in an array, in the event that a user has multiple pronouns selected.
* Added user assets. (Profile picture and icon)
* Added game release date. (Separate from year)
* Added game Twitch name.
* Patched assets being inaccessible from a breaking API update. (Width and Height were removed from image values)