### PR TITLE
Add XML documentation

### DIFF
--- a/SpeedrunComSharp/Categories/CategoriesClient.cs
+++ b/SpeedrunComSharp/Categories/CategoriesClient.cs
@@ -20,6 +20,12 @@ namespace SpeedrunComSharp
             return SpeedrunComClient.GetAPIUri(string.Format("{0}{1}", Name, subUri));
         }
 
+        /// <summary>
+        /// Fetch a Category object identified by its URI.
+        /// </summary>
+        /// <param name="siteUri">The site URI for the category.</param>
+        /// <param name="embeds">Optional. If included, will dictate the embedded resources included in the response.</param>
+        /// <returns></returns>
         public Category GetCategoryFromSiteUri(string siteUri, CategoryEmbeds embeds = default(CategoryEmbeds))
         {
             var id = GetCategoryIDFromSiteUri(siteUri);
@@ -30,6 +36,11 @@ namespace SpeedrunComSharp
             return GetCategory(id, embeds);
         }
 
+        /// <summary>
+        /// Fetch a Category ID identified by its URI.
+        /// </summary>
+        /// <param name="siteUri">The site URI for the category.</param>
+        /// <returns></returns>
         public string GetCategoryIDFromSiteUri(string siteUri)
         {
             var elementDescription = baseClient.GetElementDescriptionFromSiteUri(siteUri);
@@ -41,6 +52,12 @@ namespace SpeedrunComSharp
             return elementDescription.ID;
         }
 
+        /// <summary>
+        /// Fetch a Category object identified by its ID.
+        /// </summary>
+        /// <param name="categoryId">The ID for the category.</param>
+        /// <param name="embeds">Optional. If included, will dictate the additional resources embedded in the response.</param>
+        /// <returns></returns>
         public Category GetCategory(string categoryId, CategoryEmbeds embeds = default(CategoryEmbeds))
         {
             var uri = GetCategoriesUri(string.Format("/{0}{1}", Uri.EscapeDataString(categoryId), embeds.ToString().ToParameters()));
@@ -49,6 +66,12 @@ namespace SpeedrunComSharp
             return Category.Parse(baseClient, result.data);
         }
 
+        /// <summary>
+        /// Fetch a Collection of Variable objects from a category's ID.
+        /// </summary>
+        /// <param name="categoryId">The ID for the category.</param>
+        /// <param name="orderBy">Optional. If omitted, variables will be in the same order as the API.</param>
+        /// <returns></returns>
         public ReadOnlyCollection<Variable> GetVariables(string categoryId,
             VariablesOrdering orderBy = default(VariablesOrdering))
         {
@@ -62,6 +85,15 @@ namespace SpeedrunComSharp
                 x => Variable.Parse(baseClient, x));
         }
 
+        /// <summary>
+        /// Fetch a Leaderboard object from a category's ID.
+        /// </summary>
+        /// <param name="categoryId">The ID for the category.</param>
+        /// <param name="top">Optional. If included, will dictate the amount of top runs included in the response.</param>
+        /// <param name="skipEmptyLeaderboards">Optional. If included, will dictate whether or not empty leaderboards are included in the response.</param>
+        /// <param name="elementsPerPage">Optional. If included, will dictate the amount of elements included in each pagination.</param>
+        /// <param name="embeds">Optional. If included, will dictate the additional resources embedded in the response.</param>
+        /// <returns></returns>
         public IEnumerable<Leaderboard> GetRecords(string categoryId,
             int? top = null, bool skipEmptyLeaderboards = false,
             int? elementsPerPage = null,

--- a/SpeedrunComSharp/Categories/CategoriesOrdering.cs
+++ b/SpeedrunComSharp/Categories/CategoriesOrdering.cs
@@ -2,6 +2,9 @@
 
 namespace SpeedrunComSharp
 {
+    /// <summary>
+    /// Options for ordering Categories in responses.
+    /// </summary>
     public enum CategoriesOrdering : int
     {
         Position = 0,

--- a/SpeedrunComSharp/Categories/CategoryEmbeds.cs
+++ b/SpeedrunComSharp/Categories/CategoryEmbeds.cs
@@ -7,6 +7,11 @@
         public bool EmbedGame { get { return embeds["game"]; } set { embeds["game"] = value; } }
         public bool EmbedVariables { get { return embeds["variables"]; } set { embeds["variables"] = value; } }
 
+        /// <summary>
+        /// Options for embedding resources in Category responses.
+        /// </summary>
+        /// <param name="embedGame">Dictates whether a Game object is included in the response.</param>
+        /// <param name="embedVariables">Dictates whether a Collection of Variable objects is included in the response.</param>
         public CategoryEmbeds(
             bool embedGame = false, 
             bool embedVariables = false)

--- a/SpeedrunComSharp/Games/GameEmbeds.cs
+++ b/SpeedrunComSharp/Games/GameEmbeds.cs
@@ -35,6 +35,15 @@
             set { embeds["variables"] = value; }
         }
 
+        /// <summary>
+        /// Options for embedding resources in Game responses.
+        /// </summary>
+        /// <param name="embedLevels">Dictates whether a Collection of Level objects is included in the response.</param>
+        /// <param name="embedCategories">Dictates whether a Collection of Category objects is included in the response.</param>
+        /// <param name="embedModerators">Dictates whether a Collection of User objects containing each moderator is included in the response.</param>
+        /// <param name="embedPlatforms">Dictates whether a Collection of Platform objects is included in the response.</param>
+        /// <param name="embedRegions">Dictates whether a Collection of Region objects is included in the response.</param>
+        /// <param name="embedVariables">Dictates whether a Collection of Variable objects is included in the response.</param>
         public GameEmbeds(
             bool embedLevels = false,
             bool embedCategories = false,

--- a/SpeedrunComSharp/Games/GameHeader.cs
+++ b/SpeedrunComSharp/Games/GameHeader.cs
@@ -2,6 +2,9 @@
 
 namespace SpeedrunComSharp
 {
+    /// <summary>
+    /// An optimized class for simple data for games.
+    /// </summary>
     public class GameHeader : IElementWithID
     {
         public string ID { get; private set; }

--- a/SpeedrunComSharp/Games/GamesClient.cs
+++ b/SpeedrunComSharp/Games/GamesClient.cs
@@ -21,6 +21,12 @@ namespace SpeedrunComSharp
             return SpeedrunComClient.GetAPIUri(string.Format("{0}{1}", Name, subUri));
         }
 
+        /// <summary>
+        /// Fetch a Game object identified by its URI.
+        /// </summary>
+        /// <param name="siteUri">The site URI for the game.</param>
+        /// <param name="embeds">Optional. If included, will dictate the embedded resources included in the response.</param>
+        /// <returns></returns>
         public Game GetGameFromSiteUri(string siteUri, GameEmbeds embeds = default(GameEmbeds))
         {
             var id = GetGameIDFromSiteUri(siteUri);
@@ -31,6 +37,11 @@ namespace SpeedrunComSharp
             return GetGame(id, embeds);
         }
 
+        /// <summary>
+        /// Fetch a Game ID identified by its URI.
+        /// </summary>
+        /// <param name="siteUri">The site URI for the game.</param>
+        /// <returns></returns>
         public string GetGameIDFromSiteUri(string siteUri)
         {
             var elementDescription = baseClient.GetElementDescriptionFromSiteUri(siteUri);
@@ -42,6 +53,18 @@ namespace SpeedrunComSharp
             return elementDescription.ID;
         }
 
+        /// <summary>
+        /// Fetch a Collection of Game objects identified by the parameters provided.
+        /// </summary>
+        /// <param name="name">Optional. If included, will filter games by their name.</param>
+        /// <param name="yearOfRelease">Optional. If included, will filter games by their release year.</param>
+        /// <param name="platformId">Optional. If included, will filter games by their platform.</param>
+        /// <param name="regionId">Optional. If included, will filter games by their region.</param>
+        /// <param name="moderatorId">Optional. If included, will filter games by their moderators.</param>
+        /// <param name="elementsPerPage">Optional. If included, will dictate the amount of elements included in each pagination.</param>
+        /// <param name="embeds">Optional. If included, will dictate the additional resources embedded in the response.</param>
+        /// <param name="orderBy">Optional. If omitted, games will be in the same order as the API.</param>
+        /// <returns></returns>
         public IEnumerable<Game> GetGames(
             string name = null, int? yearOfRelease = null, 
             string platformId = null, string regionId = null, 
@@ -76,6 +99,12 @@ namespace SpeedrunComSharp
                 x => Game.Parse(baseClient, x) as Game);
         }
 
+        /// <summary>
+        /// Fetch a Collection of GameHeader objects.
+        /// </summary>
+        /// <param name="elementsPerPage">Optional. If included, will dictate the amount of elements included in each pagination.</param>
+        /// <param name="orderBy">Optional. If omitted, gameheaders will be in the same order as the API.</param>
+        /// <returns></returns>
         public IEnumerable<GameHeader> GetGameHeaders(int elementsPerPage = 1000,
             GamesOrdering orderBy = default(GamesOrdering))
         {
@@ -90,6 +119,12 @@ namespace SpeedrunComSharp
                 x => GameHeader.Parse(baseClient, x) as GameHeader);
         }
 
+        /// <summary>
+        /// Fetch a Game object identified by its ID.
+        /// </summary>
+        /// <param name="gameId">The ID for the game.</param>
+        /// <param name="embeds">Optional. If included, will dictate the additional resources embedded in the response.</param>
+        /// <returns></returns>
         public Game GetGame(string gameId, GameEmbeds embeds = default(GameEmbeds))
         {
             var parameters = new List<string>() { embeds.ToString() };
@@ -103,6 +138,12 @@ namespace SpeedrunComSharp
             return Game.Parse(baseClient, result.data);
         }
         
+        /// <summary>
+        /// Fetch a Game object identified by its name.
+        /// </summary>
+        /// <param name="name">The name of the game.</param>
+        /// <param name="embeds">Optional. If included, will dictate the additional resources embedded in the response.</param>
+        /// <returns></returns>
         public Game SearchGame(string name, GameEmbeds embeds = default(GameEmbeds))
         {
             var game = GetGames(name: name, embeds: embeds, elementsPerPage: 1).FirstOrDefault();
@@ -110,6 +151,12 @@ namespace SpeedrunComSharp
             return game;
         }
 
+        /// <summary>
+        /// Fetch a Game object identified by its name with an exact match.
+        /// </summary>
+        /// <param name="name">The name of the game.</param>
+        /// <param name="embeds">Optional. If included, will dictate the additional resources embedded in the response.</param>
+        /// <returns></returns>
         public Game SearchGameExact(string name, GameEmbeds embeds = default(GameEmbeds))
         {
             var game = GetGames(name: name, embeds: embeds, elementsPerPage: 1).Take(1).FirstOrDefault(x => x.Name == name);
@@ -117,6 +164,14 @@ namespace SpeedrunComSharp
             return game;
         }
 
+        /// <summary>
+        /// Fetch a Collection of Category objects from a game's ID.
+        /// </summary>
+        /// <param name="gameId">The ID for the game.</param>
+        /// <param name="miscellaneous">Optional. If included, will dictate whether miscellaneous categories are included.</param>
+        /// <param name="embeds">Optional. If included, will dictate the additional resources embedded in the response.</param>
+        /// <param name="orderBy">Optional. If omitted, categories will be in the same order as the API.</param>
+        /// <returns></returns>
         public ReadOnlyCollection<Category> GetCategories(
             string gameId, bool miscellaneous = true,
             CategoryEmbeds embeds = default(CategoryEmbeds),
@@ -137,6 +192,13 @@ namespace SpeedrunComSharp
                 x => Category.Parse(baseClient, x) as Category);
         }
 
+        /// <summary>
+        /// Fetch a Collection of Level objects from a game's ID.
+        /// </summary>
+        /// <param name="gameId">The ID for the game.</param>
+        /// <param name="embeds">Optional. If included, will dictate the additional resources embedded in the response.</param>
+        /// <param name="orderBy">Optional. If omitted, levels will be in the same order as the API.</param>
+        /// <returns></returns>
         public ReadOnlyCollection<Level> GetLevels(string gameId,
             LevelEmbeds embeds = default(LevelEmbeds),
             LevelsOrdering orderBy = default(LevelsOrdering))
@@ -153,6 +215,12 @@ namespace SpeedrunComSharp
                  x => Level.Parse(baseClient, x) as Level);
         }
 
+        /// <summary>
+        /// Fetch a Collection of Variable objects from a game's ID.
+        /// </summary>
+        /// <param name="gameId">The ID for the category.</param>
+        /// <param name="orderBy">Optional. If omitted, variables will be in the same order as the API.</param>
+        /// <returns></returns>
         public ReadOnlyCollection<Variable> GetVariables(string gameId,
             VariablesOrdering orderBy = default(VariablesOrdering))
         {
@@ -166,6 +234,13 @@ namespace SpeedrunComSharp
                 x => Variable.Parse(baseClient, x) as Variable);
         }
 
+        /// <summary>
+        /// Fetch a Collection of Game objects derived from a game's ID.
+        /// </summary>
+        /// <param name="gameId">The ID for the game.</param>
+        /// <param name="embeds">Optional. If included, will dictate the additional resources embedded in the response.</param>
+        /// <param name="orderBy">Optional. If omitted, games will be in the same order as the API.</param>
+        /// <returns></returns>
         public ReadOnlyCollection<Game> GetRomHacks(string gameId,
             GameEmbeds embeds = default(GameEmbeds),
             GamesOrdering orderBy = default(GamesOrdering))
@@ -182,6 +257,17 @@ namespace SpeedrunComSharp
                 x => Game.Parse(baseClient, x) as Game);
         }
 
+        /// <summary>
+        /// Fetch a Leaderboard object from a game's ID.
+        /// </summary>
+        /// <param name="gameId">The ID for the game.</param>
+        /// <param name="top">Optional. If included, will dictate the amount of top runs included in the response.</param>
+        /// <param name="scope">Optional. If included, will dictate the scope of the Leaderboard included in the response.</param>
+        /// <param name="includeMiscellaneousCategories">Optional. If included, will dictate whether miscellaneous categories are included.</param>
+        /// <param name="skipEmptyLeaderboards">Optional. If included, will dictate whether or not empty leaderboards are included in the response.</param>
+        /// <param name="elementsPerPage">Optional. If included, will dictate the amount of elements included in each pagination.</param>
+        /// <param name="embeds">Optional. If included, will dictate the additional resources embedded in the response.</param>
+        /// <returns></returns>
         public IEnumerable<Leaderboard> GetRecords(string gameId,
             int? top = null, LeaderboardScope scope = LeaderboardScope.All,
             bool includeMiscellaneousCategories = true, bool skipEmptyLeaderboards = false,

--- a/SpeedrunComSharp/Games/GamesOrdering.cs
+++ b/SpeedrunComSharp/Games/GamesOrdering.cs
@@ -2,6 +2,9 @@
 
 namespace SpeedrunComSharp
 {
+    /// <summary>
+    /// Options for ordering Games in responses.
+    /// </summary>
     public enum GamesOrdering : int
     {
         Similarity = 0,

--- a/SpeedrunComSharp/Guests/GuestsClient.cs
+++ b/SpeedrunComSharp/Guests/GuestsClient.cs
@@ -18,6 +18,11 @@ namespace SpeedrunComSharp
             return SpeedrunComClient.GetAPIUri(string.Format("{0}{1}", Name, subUri));
         }
 
+        /// <summary>
+        /// Fetch a Guest object identified by its URI.
+        /// </summary>
+        /// <param name="siteUri">The site URI for the guest.</param>
+        /// <returns></returns>
         public Guest GetGuestFromSiteUri(string siteUri)
         {
             var id = GetGuestIDFromSiteUri(siteUri);
@@ -28,6 +33,11 @@ namespace SpeedrunComSharp
             return GetGuest(id);
         }
 
+        /// <summary>
+        /// Fetch a Guest ID identified by its URI.
+        /// </summary>
+        /// <param name="siteUri">The site URI for the guest.</param>
+        /// <returns></returns>
         public string GetGuestIDFromSiteUri(string siteUri)
         {
             var elementDescription = baseClient.GetElementDescriptionFromSiteUri(siteUri);
@@ -39,6 +49,11 @@ namespace SpeedrunComSharp
             return elementDescription.ID;
         }
 
+        /// <summary>
+        /// Fetch a Guest object identified by its name.
+        /// </summary>
+        /// <param name="guestName">The name of the guest.</param>
+        /// <returns></returns>
         public Guest GetGuest(string guestName)
         {
             var uri = GetGuestsUri(string.Format("/{0}", Uri.EscapeDataString(guestName)));

--- a/SpeedrunComSharp/Leaderboards/EmulatorsFilter.cs
+++ b/SpeedrunComSharp/Leaderboards/EmulatorsFilter.cs
@@ -1,5 +1,8 @@
 ﻿namespace SpeedrunComSharp
 {
+    /// <summary>
+    /// Filters for whether emulators are included in Leaderboards.
+    /// </summary>
     public enum EmulatorsFilter
     {
         NotSet,

--- a/SpeedrunComSharp/Leaderboards/LeaderboardEmbeds.cs
+++ b/SpeedrunComSharp/Leaderboards/LeaderboardEmbeds.cs
@@ -47,6 +47,16 @@
             set { embeds["variables"] = value; }
         }
 
+        /// <summary>
+        /// Options for embedding resources in Leaderboard responses.
+        /// </summary>
+        /// <param name="embedGame">Dictates whether a Game object is included in the response.</param>
+        /// <param name="embedCategory">Dictates whether a Category object is included in the response.</param>
+        /// <param name="embedLevel">Dictates whether a Level object is included in the response.</param>
+        /// <param name="embedPlayers">Dictates whether a Collection of Player objects is included in the response.</param>
+        /// <param name="embedRegions">Dictates whether a Collection of Region objects is included in the response.</param>
+        /// <param name="embedPlatforms">Dictates whether a Collection of Platform objects is included in the response.</param>
+        /// <param name="embedVariables">Dictates whether a Collection of Variable objects is included in the response.</param>
         public LeaderboardEmbeds(
             bool embedGame = false,
             bool embedCategory = false,

--- a/SpeedrunComSharp/Leaderboards/LeaderboardsClient.cs
+++ b/SpeedrunComSharp/Leaderboards/LeaderboardsClient.cs
@@ -73,6 +73,21 @@ namespace SpeedrunComSharp
             return Leaderboard.Parse(baseClient, result.data);
         }
 
+        /// <summary>
+        /// Fetch a Leaderboard object identified by the game ID and category ID.
+        /// </summary>
+        /// <param name="gameId">The ID for the game.</param>
+        /// <param name="categoryId">The ID for the category.</param>
+        /// <param name="top">Optional. If included, will dictate the amount of top runs included in the response.</param>
+        /// <param name="platformId">Optional. If included, will filter runs by their platform.</param>
+        /// <param name="regionId">Optional. If included, will filter runs by their region.</param>
+        /// <param name="emulatorsFilter">Optional. If included, will filter runs by their use of emulator.</param>
+        /// <param name="filterOutRunsWithoutVideo">Optional. If included, will dictate whether runs without video are included in the response.</param>
+        /// <param name="orderBy">Optional. If omitted, runs will be in the same order as the API.</param>
+        /// <param name="filterOutRunsAfter">Optional. If included, will filter out runs performed after the specified DateTime.</param>
+        /// <param name="variableFilters">Optional. If included, will filter runs by the values present in specific variables.</param>
+        /// <param name="embeds">Optional. If included, will dictate the additional resources embedded in the response.</param>
+        /// <returns></returns>
         public Leaderboard GetLeaderboardForFullGameCategory(
             string gameId, string categoryId,
             int? top = null,
@@ -95,6 +110,22 @@ namespace SpeedrunComSharp
                 embeds);
         }
 
+        /// <summary>
+        /// Fetch a Leaderboard object identified by the game ID, level ID, and category ID.
+        /// </summary>
+        /// <param name="gameId">The ID for the game.</param>
+        /// <param name="levelId">The ID for the level.</param>
+        /// <param name="categoryId">The ID for the category.</param>
+        /// <param name="top">Optional. If included, will dictate the amount of top runs included in the response.</param>
+        /// <param name="platformId">Optional. If included, will filter runs by their platform.</param>
+        /// <param name="regionId">Optional. If included, will filter runs by their region.</param>
+        /// <param name="emulatorsFilter">Optional. If included, will filter runs by their use of emulator.</param>
+        /// <param name="filterOutRunsWithoutVideo">Optional. If included, will dictate whether runs without video are included in the response.</param>
+        /// <param name="orderBy">Optional. If omitted, runs will be in the same order as the API.</param>
+        /// <param name="filterOutRunsAfter">Optional. If included, will filter out runs performed after the specified DateTime.</param>
+        /// <param name="variableFilters">Optional. If included, will filter runs by the values present in specific variables.</param>
+        /// <param name="embeds">Optional. If included, will dictate the additional resources embedded in the response.</param>
+        /// <returns></returns>
         public Leaderboard GetLeaderboardForLevel(
             string gameId, string levelId, string categoryId,
             int? top = null,

--- a/SpeedrunComSharp/Levels/LevelEmbeds.cs
+++ b/SpeedrunComSharp/Levels/LevelEmbeds.cs
@@ -15,6 +15,11 @@
             set { embeds["variables"] = value; }
         }
 
+        /// <summary>
+        /// Options for embedding resources in Level responses.
+        /// </summary>
+        /// <param name="embedCategories">Dictates whether a Collection of Category objects is included in the response.</param>
+        /// <param name="embedVariables">Dictates whether a Collection of Variable objects is included in the response.</param>
         public LevelEmbeds(
             bool embedCategories = false,
             bool embedVariables = false)

--- a/SpeedrunComSharp/Levels/LevelsClient.cs
+++ b/SpeedrunComSharp/Levels/LevelsClient.cs
@@ -20,6 +20,12 @@ namespace SpeedrunComSharp
             return SpeedrunComClient.GetAPIUri(string.Format("{0}{1}", Name, subUri));
         }
 
+        /// <summary>
+        /// Fetch a Level object identified by its URI.
+        /// </summary>
+        /// <param name="siteUri">The site URI for the level.</param>
+        /// <param name="embeds">Optional. If included, will dictate the embedded resources included in the response.</param>
+        /// <returns></returns>
         public Level GetLevelFromSiteUri(string siteUri, LevelEmbeds embeds = default(LevelEmbeds))
         {
             var id = GetLevelIDFromSiteUri(siteUri);
@@ -30,6 +36,11 @@ namespace SpeedrunComSharp
             return GetLevel(id, embeds);
         }
 
+        /// <summary>
+        /// Fetch a Level ID identified by its URI.
+        /// </summary>
+        /// <param name="siteUri">The site URI for the level.</param>
+        /// <returns></returns>
         public string GetLevelIDFromSiteUri(string siteUri)
         {
             var elementDescription = baseClient.GetElementDescriptionFromSiteUri(siteUri);
@@ -41,6 +52,12 @@ namespace SpeedrunComSharp
             return elementDescription.ID;
         }
 
+        /// <summary>
+        /// Fetch a Level object identified by its ID.
+        /// </summary>
+        /// <param name="levelId">The ID for the level.</param>
+        /// <param name="embeds">Optional. If included, will dictate the embedded resources included in the response.</param>
+        /// <returns></returns>
         public Level GetLevel(string levelId, 
             LevelEmbeds embeds = default(LevelEmbeds))
         {
@@ -55,6 +72,14 @@ namespace SpeedrunComSharp
             return Level.Parse(baseClient, result.data);
         }
 
+        /// <summary>
+        /// Fetch a Collection of Category objects from a level's ID.
+        /// </summary>
+        /// <param name="levelId">The ID for the level.</param>
+        /// <param name="miscellaneous">Optional. If included, will dictate whether miscellaneous categories are included.</param>
+        /// <param name="embeds">Optional. If included, will dictate the additional resources embedded in the response.</param>
+        /// <param name="orderBy">Optional. If omitted, categories will be in the same order as the API.</param>
+        /// <returns></returns>
         public ReadOnlyCollection<Category> GetCategories(
             string levelId, bool miscellaneous = true,
             CategoryEmbeds embeds = default(CategoryEmbeds),
@@ -75,6 +100,12 @@ namespace SpeedrunComSharp
                 x => Category.Parse(baseClient, x));
         }
 
+        /// <summary>
+        /// Fetch a Collection of Variable objects from a level's ID.
+        /// </summary>
+        /// <param name="levelId">The ID for the level.</param>
+        /// <param name="orderBy">Optional. If omitted, variables will be in the same order as the API.</param>
+        /// <returns></returns>
         public ReadOnlyCollection<Variable> GetVariables(string levelId,
             VariablesOrdering orderBy = default(VariablesOrdering))
         {
@@ -88,6 +119,15 @@ namespace SpeedrunComSharp
                 x => Variable.Parse(baseClient, x));
         }
 
+        /// <summary>
+        /// Fetch a Leaderboard object from a level's ID.
+        /// </summary>
+        /// <param name="levelId">The ID for the level.</param>
+        /// <param name="top">Optional. If included, will dictate the amount of top runs included in the response.</param>
+        /// <param name="skipEmptyLeaderboards">Optional. If included, will dictate whether or not empty leaderboards are included in the response.</param>
+        /// <param name="elementsPerPage">Optional. If included, will dictate the amount of elements included in each pagination.</param>
+        /// <param name="embeds">Optional. If included, will dictate the additional resources embedded in the response.</param>
+        /// <returns></returns>
         public IEnumerable<Leaderboard> GetRecords(string levelId,
            int? top = null, bool skipEmptyLeaderboards = false,
            int? elementsPerPage = null,

--- a/SpeedrunComSharp/Levels/LevelsOrdering.cs
+++ b/SpeedrunComSharp/Levels/LevelsOrdering.cs
@@ -2,6 +2,9 @@
 
 namespace SpeedrunComSharp
 {
+    /// <summary>
+    /// Options for ordering Levels in responses.
+    /// </summary>
     public enum LevelsOrdering : int
     {
         Position = 0,

--- a/SpeedrunComSharp/Notifications/NotificationsClient.cs
+++ b/SpeedrunComSharp/Notifications/NotificationsClient.cs
@@ -19,6 +19,12 @@ namespace SpeedrunComSharp
             return SpeedrunComClient.GetAPIUri(string.Format("{0}{1}", Name, subUri));
         }
 
+        /// <summary>
+        /// Fetch a Collection of Notification objects. Authentication is required for this action.
+        /// </summary>
+        /// <param name="elementsPerPage">Optional. If included, will dictate the amount of elements included in each pagination.</param>
+        /// <param name="ordering">Optional. If omitted, notifications will be from newest to oldest.</param>
+        /// <returns></returns>
         public IEnumerable<Notification> GetNotifications(
             int? elementsPerPage = null,
             NotificationsOrdering ordering = default(NotificationsOrdering))

--- a/SpeedrunComSharp/Notifications/NotificationsOrdering.cs
+++ b/SpeedrunComSharp/Notifications/NotificationsOrdering.cs
@@ -2,6 +2,9 @@
 
 namespace SpeedrunComSharp
 {
+    /// <summary>
+    /// Options for ordering Notifications in responses.
+    /// </summary>
     public enum NotificationsOrdering : int
     {
         NewestToOldest = 0,

--- a/SpeedrunComSharp/Platforms/PlatformsClient.cs
+++ b/SpeedrunComSharp/Platforms/PlatformsClient.cs
@@ -19,6 +19,11 @@ namespace SpeedrunComSharp
             return SpeedrunComClient.GetAPIUri(string.Format("{0}{1}", Name, subUri));
         }
 
+        /// <summary>
+        /// Fetch a Platform object identified by its URI.
+        /// </summary>
+        /// <param name="siteUri">The site URI for the platform.</param>
+        /// <returns></returns>
         public Platform GetPlatformFromSiteUri(string siteUri)
         {
             var id = GetPlatformIDFromSiteUri(siteUri);
@@ -29,6 +34,11 @@ namespace SpeedrunComSharp
             return GetPlatform(id);
         }
 
+        /// <summary>
+        /// Fetch a Platform ID identified by its URI.
+        /// </summary>
+        /// <param name="siteUri">The site URI for the platform.</param>
+        /// <returns></returns>
         public string GetPlatformIDFromSiteUri(string siteUri)
         {
             var elementDescription = baseClient.GetElementDescriptionFromSiteUri(siteUri);
@@ -40,6 +50,12 @@ namespace SpeedrunComSharp
             return elementDescription.ID;
         }
 
+        /// <summary>
+        /// Fetch a Collection of Platform objects.
+        /// </summary>
+        /// <param name="elementsPerPage">Optional. If included, will dictate the amount of elements included in each pagination.</param>
+        /// <param name="orderBy">Optional. If omitted, platforms will be in the same order as the API.</param>
+        /// <returns></returns>
         public IEnumerable<Platform> GetPlatforms(int? elementsPerPage = null,
             PlatformsOrdering orderBy = default(PlatformsOrdering))
         {
@@ -56,6 +72,11 @@ namespace SpeedrunComSharp
                 x => Platform.Parse(baseClient, x) as Platform);
         }
 
+        /// <summary>
+        /// Fetch a Platform object identified by its ID.
+        /// </summary>
+        /// <param name="platformId">The ID for the platform.</param>
+        /// <returns></returns>
         public Platform GetPlatform(string platformId)
         {
             var uri = GetPlatformsUri(string.Format("/{0}", Uri.EscapeDataString(platformId)));

--- a/SpeedrunComSharp/Platforms/PlatformsOrdering.cs
+++ b/SpeedrunComSharp/Platforms/PlatformsOrdering.cs
@@ -2,6 +2,9 @@
 
 namespace SpeedrunComSharp
 {
+    /// <summary>
+    /// Options for ordering Platforms in responses.
+    /// </summary>
     public enum PlatformsOrdering : int
     {
         Name = 0,

--- a/SpeedrunComSharp/Regions/RegionsClient.cs
+++ b/SpeedrunComSharp/Regions/RegionsClient.cs
@@ -18,6 +18,11 @@ namespace SpeedrunComSharp
             return SpeedrunComClient.GetAPIUri(string.Format("{0}{1}", Name, subUri));
         }
 
+        /// <summary>
+        /// Fetch a Region object identified by its URI.
+        /// </summary>
+        /// <param name="siteUri">The site URI for the region.</param>
+        /// <returns></returns>
         public Region GetRegionFromSiteUri(string siteUri)
         {
             var id = GetRegionIDFromSiteUri(siteUri);
@@ -28,6 +33,11 @@ namespace SpeedrunComSharp
             return GetRegion(id);
         }
 
+        /// <summary>
+        /// Fetch a Region ID identified by its URI.
+        /// </summary>
+        /// <param name="siteUri">The site URI for the region.</param>
+        /// <returns></returns>
         public string GetRegionIDFromSiteUri(string siteUri)
         {
             var elementDescription = baseClient.GetElementDescriptionFromSiteUri(siteUri);
@@ -39,6 +49,12 @@ namespace SpeedrunComSharp
             return elementDescription.ID;
         }
 
+        /// <summary>
+        /// Fetch a Collection of Region objects.
+        /// </summary>
+        /// <param name="elementsPerPage">Optional. If included, will dictate the amount of elements included in each pagination.</param>
+        /// <param name="orderBy">Optional. If omitted, regions will be in the same order as the API.</param>
+        /// <returns></returns>
         public IEnumerable<Region> GetRegions(int? elementsPerPage = null,
             RegionsOrdering orderBy = default(RegionsOrdering))
         {
@@ -55,6 +71,11 @@ namespace SpeedrunComSharp
                 x => Region.Parse(baseClient, x) as Region);
         }
 
+        /// <summary>
+        /// Fetch a Region object identified by its ID.
+        /// </summary>
+        /// <param name="regionId">The ID for the region.</param>
+        /// <returns></returns>
         public Region GetRegion(string regionId)
         {
             var uri = GetRegionsUri(string.Format("/{0}", Uri.EscapeDataString(regionId)));

--- a/SpeedrunComSharp/Regions/RegionsOrdering.cs
+++ b/SpeedrunComSharp/Regions/RegionsOrdering.cs
@@ -2,6 +2,9 @@
 
 namespace SpeedrunComSharp
 {
+    /// <summary>
+    /// Options for ordering Regions in responses.
+    /// </summary>
     public enum RegionsOrdering : int
     {
         Name = 0,

--- a/SpeedrunComSharp/Runs/RunEmbeds.cs
+++ b/SpeedrunComSharp/Runs/RunEmbeds.cs
@@ -40,6 +40,15 @@
             set { embeds["platform"] = value; }
         }
 
+        /// <summary>
+        /// Options for embedding resources in Run responses.
+        /// </summary>
+        /// <param name="embedGame">Dictates whether a Game object is included in the response.</param>
+        /// <param name="embedCategory">Dictates whether a Category object is included in the response.</param>
+        /// <param name="embedLevel">Dictates whether a Level object is included in the response.</param>
+        /// <param name="embedPlayers">Dictates whether a Collection of Runner objects containing each runner is included in the response.</param>
+        /// <param name="embedRegion">Dictates whether a Region object is included in the response.</param>
+        /// <param name="embedPlatform">Dictates whether a Platform object is included in the response.</param>
         public RunEmbeds(
             bool embedGame = false,
             bool embedCategory = false,

--- a/SpeedrunComSharp/Runs/RunsClient.cs
+++ b/SpeedrunComSharp/Runs/RunsClient.cs
@@ -21,6 +21,12 @@ namespace SpeedrunComSharp
             return SpeedrunComClient.GetAPIUri(string.Format("{0}{1}", Name, subUri));
         }
 
+        /// <summary>
+        /// Fetch a Run object identified by its URI.
+        /// </summary>
+        /// <param name="siteUri">The site URI for the run.</param>
+        /// <param name="embeds">Optional. If included, will dictate the embedded resources included in the response.</param>
+        /// <returns></returns>
         public Run GetRunFromSiteUri(string siteUri, RunEmbeds embeds = default(RunEmbeds))
         {
             var id = GetRunIDFromSiteUri(siteUri);
@@ -31,6 +37,11 @@ namespace SpeedrunComSharp
             return GetRun(id, embeds);
         }
 
+        /// <summary>
+        /// Fetch a Run ID identified by its URI.
+        /// </summary>
+        /// <param name="siteUri">The site URI for the run.</param>
+        /// <returns></returns>
         public string GetRunIDFromSiteUri(string siteUri)
         {
             var elementDescription = baseClient.GetElementDescriptionFromSiteUri(siteUri);
@@ -42,6 +53,23 @@ namespace SpeedrunComSharp
             return elementDescription.ID;
         }
 
+        /// <summary>
+        /// Fetch a Collection of Run objects identified by the parameters provided.
+        /// </summary>
+        /// <param name="userId">Optional. If included, will filter runs by the user ID of the runner(s).</param>
+        /// <param name="guestName">Optional. If included, will filter runs by the name of the guest runner(s).</param>
+        /// <param name="examerUserId">Optional. If included, will filter runs by the user ID of the examiner.</param>
+        /// <param name="gameId">Optional. If included, will filter runs by the ID of the corresponding game.</param>
+        /// <param name="levelId">Optional. If included, will filter runs by the ID of the corresponding level.</param>
+        /// <param name="categoryId">Optional. If included, will filter runs by the ID of the corresponding category</param>
+        /// <param name="platformId">Optional. If included, will filter runs by their platform.</param>
+        /// <param name="regionId">Optional. If included, will filter runs by their region.</param>
+        /// <param name="onlyEmulatedRuns">Optional. If included, will filter runs by their use of emulator.</param>
+        /// <param name="status">Optional. If included, will filter runs by their verification status.</param>
+        /// <param name="elementsPerPage">Optional. If included, will dictate the amount of elements included in each pagination.</param>
+        /// <param name="embeds">Optional. If included, will dictate the additional resources embedded in the response.</param>
+        /// <param name="orderBy">Optional. If omitted, runs will be in the same order as the API.</param>
+        /// <returns></returns>
         public IEnumerable<Run> GetRuns(
             string userId = null, string guestName = null,
             string examerUserId = null, string gameId = null,
@@ -94,6 +122,12 @@ namespace SpeedrunComSharp
                 x => Run.Parse(baseClient, x) as Run);
         }
 
+        /// <summary>
+        /// Fetch a Run object identified by its ID.
+        /// </summary>
+        /// <param name="runId">The ID of the run.</param>
+        /// <param name="embeds">Optional. If included, will dictate the additional resources embedded in the response.</param>
+        /// <returns></returns>
         public Run GetRun(string runId,
             RunEmbeds embeds = default(RunEmbeds))
         {
@@ -108,6 +142,25 @@ namespace SpeedrunComSharp
             return Run.Parse(baseClient, result.data);
         }
 
+        /// <summary>
+        /// Posts a Run object to Speedrun.com. Authentication is required for this action.
+        /// </summary>
+        /// <param name="categoryId">The ID of the category.</param>
+        /// <param name="platformId">The ID of the platform.</param>
+        /// <param name="levelId">Optional. If included, dictates the ID of the level.</param>
+        /// <param name="date">Optional. If included, dictates the date of the run.</param>
+        /// <param name="regionId">Optional. If included, dictates the ID of the region.</param>
+        /// <param name="realTime">Optional. If included, dictates real time.</param>
+        /// <param name="realTimeWithoutLoads">Optional. If included, dictates Real Time without loads.</param>
+        /// <param name="gameTime">Optional. If included, dictates in game time.</param>
+        /// <param name="emulated">Optional. If included, dictates whether the run was performed on emulator.</param>
+        /// <param name="videoUri">Optional. If included, dictates the URI of the video.</param>
+        /// <param name="comment">Optional. If included, dictates the comment of the run.</param>
+        /// <param name="splitsIOUri">Optional. If included, dictates the URI of the Splits.IO page for the run.</param>
+        /// <param name="variables">Optional. If included, dictates the variable values for the run.</param>
+        /// <param name="verify">Optional. If included, dictates whether the run is verified automatically upon submitting.</param>
+        /// <param name="simulateSubmitting">Optional. If included, dictates whether the run submission process is simulated.</param>
+        /// <returns></returns>
         public Run Submit(string categoryId,
             string platformId,
             string levelId = null,

--- a/SpeedrunComSharp/Runs/RunsOrdering.cs
+++ b/SpeedrunComSharp/Runs/RunsOrdering.cs
@@ -2,6 +2,9 @@
 
 namespace SpeedrunComSharp
 {
+    /// <summary>
+    /// Options for ordering Runs in responses.
+    /// </summary>
     public enum RunsOrdering : int
     {
         Game = 0,

--- a/SpeedrunComSharp/Series/SeriesClient.cs
+++ b/SpeedrunComSharp/Series/SeriesClient.cs
@@ -19,6 +19,12 @@ namespace SpeedrunComSharp
             return SpeedrunComClient.GetAPIUri(string.Format("{0}{1}", Name, subUri));
         }
 
+        /// <summary>
+        /// Fetch a Series object identified by its URI.
+        /// </summary>
+        /// <param name="siteUri">The site URI for the series.</param>
+        /// <param name="embeds">Optional. If included, will dictate the embedded resources included in the response.</param>
+        /// <returns></returns>
         public Series GetSeriesFromSiteUri(string siteUri, SeriesEmbeds embeds = default(SeriesEmbeds))
         {
             var id = GetSeriesIDFromSiteUri(siteUri);
@@ -29,6 +35,11 @@ namespace SpeedrunComSharp
             return GetSingleSeries(id, embeds);
         }
 
+        /// <summary>
+        /// Fetch a Series ID identified by its URI.
+        /// </summary>
+        /// <param name="siteUri">The site URI for the series.</param>
+        /// <returns></returns>
         public string GetSeriesIDFromSiteUri(string siteUri)
         {
             var elementDescription = baseClient.GetElementDescriptionFromSiteUri(siteUri);
@@ -40,6 +51,16 @@ namespace SpeedrunComSharp
             return elementDescription.ID;
         }
 
+        /// <summary>
+        /// Fetch a Collection of Series objects identified by the parameters provided.
+        /// </summary>
+        /// <param name="name">Optional. If included, will filter series by their name.</param>
+        /// <param name="abbreviation">Optional. If included, will filter series by their abbreviation.</param>
+        /// <param name="moderatorId">Optional. If included, will filter series by their moderators.</param>
+        /// <param name="elementsPerPage">Optional. If included, will dictate the amount of elements included in each pagination.</param>
+        /// <param name="embeds">Optional. If included, will dictate the additional resources embedded in the response.</param>
+        /// <param name="orderBy">Optional. If omitted, series will be in the same order as the API.</param>
+        /// <returns></returns>
         public IEnumerable<Series> GetMultipleSeries(
            string name = null, string abbreviation = null,
            string moderatorId = null, int? elementsPerPage = null,
@@ -67,6 +88,12 @@ namespace SpeedrunComSharp
                 x => Series.Parse(baseClient, x) as Series);
         }
 
+        /// <summary>
+        /// Fetch a Series object identified by its ID.
+        /// </summary>
+        /// <param name="seriesId">The ID of the series.</param>
+        /// <param name="embeds">Optional. If included, will dictate the additional resources embedded in the response.</param>
+        /// <returns></returns>
         public Series GetSingleSeries(string seriesId, SeriesEmbeds embeds = default(SeriesEmbeds))
         {
             var parameters = new List<string>() { embeds.ToString() };
@@ -80,6 +107,19 @@ namespace SpeedrunComSharp
             return Series.Parse(baseClient, result.data);
         }
 
+        /// <summary>
+        /// 
+        /// </summary>
+        /// <param name="seriesId">The ID of the series.</param>
+        /// <param name="name">Optional. If included, will filter series by their name.</param>
+        /// <param name="yearOfRelease">Optional. If included, will filter series by their release year.</param>
+        /// <param name="platformId">Optional. If included, will filter series by their platform.</param>
+        /// <param name="regionId">Optional. If included, will filter series by their region.</param>
+        /// <param name="moderatorId">Optional. If included, will filter series by their moderators.</param>
+        /// <param name="elementsPerPage">Optional. If included, will dictate the amount of elements included in each pagination.</param>
+        /// <param name="embeds">Optional. If included, will dictate the additional resources embedded in the response.</param>
+        /// <param name="orderBy">Optional. If omitted, series will be in the same order as the API.</param>
+        /// <returns></returns>
         public IEnumerable<Game> GetGames(
             string seriesId,
             string name = null, int? yearOfRelease = null,

--- a/SpeedrunComSharp/Series/SeriesEmbeds.cs
+++ b/SpeedrunComSharp/Series/SeriesEmbeds.cs
@@ -10,6 +10,10 @@
             set { embeds["moderators"] = value; }
         }
 
+        /// <summary>
+        /// Options for embedding resources in Series responses.
+        /// </summary>
+        /// <param name="embedModerators">Dictates whether a Collection of User objects containing each moderator is included in the response.</param>
         public SeriesEmbeds(
             bool embedModerators = false)
         {

--- a/SpeedrunComSharp/Series/SeriesOrdering.cs
+++ b/SpeedrunComSharp/Series/SeriesOrdering.cs
@@ -2,6 +2,9 @@
 
 namespace SpeedrunComSharp
 {
+    /// <summary>
+    /// Options for ordering Series in responses.
+    /// </summary>
     public enum SeriesOrdering : int
     {
         Name = 0,

--- a/SpeedrunComSharp/SpeedrunComClient.cs
+++ b/SpeedrunComSharp/SpeedrunComClient.cs
@@ -39,17 +39,53 @@ namespace SpeedrunComSharp
 
         public TimeSpan Timeout { get; private set; }
 
+        /// <summary>
+        /// Methods for interacting with Categories.
+        /// </summary>
         public CategoriesClient Categories { get; private set; }
+        /// <summary>
+        /// Methods for interacting with Games.
+        /// </summary>
         public GamesClient Games { get; private set; }
+        /// <summary>
+        /// Methods for interacting with Guest users.
+        /// </summary>
         public GuestsClient Guests { get; private set; }
+        /// <summary>
+        /// Methods for interacting with Leaderboards.
+        /// </summary>
         public LeaderboardsClient Leaderboards { get; private set; }
+        /// <summary>
+        /// Methods for interacting with Levels.
+        /// </summary>
         public LevelsClient Levels { get; private set; }
+        /// <summary>
+        /// Methods for interacting with Notifications.
+        /// </summary>
         public NotificationsClient Notifications { get; private set; }
+        /// <summary>
+        /// Methods for interacting with Platforms.
+        /// </summary>
         public PlatformsClient Platforms { get; private set; }
+        /// <summary>
+        /// Methods for interacting with Regions.
+        /// </summary>
         public RegionsClient Regions { get; private set; }
+        /// <summary>
+        /// Methods for interacting with Runs.
+        /// </summary>
         public RunsClient Runs { get; private set; }
+        /// <summary>
+        /// Methods for interacting with Series.
+        /// </summary>
         public SeriesClient Series { get; private set; }
+        /// <summary>
+        /// Methods for interacting with Users.
+        /// </summary>
         public UsersClient Users { get; private set; }
+        /// <summary>
+        /// Methods for interacting with Variables.
+        /// </summary>
         public VariablesClient Variables { get; private set; }
 
         public User Profile

--- a/SpeedrunComSharp/SpeedrunComSharp.csproj
+++ b/SpeedrunComSharp/SpeedrunComSharp.csproj
@@ -22,6 +22,8 @@
     <ErrorReport>prompt</ErrorReport>
     <WarningLevel>4</WarningLevel>
     <Prefer32Bit>false</Prefer32Bit>
+    <DocumentationFile>bin\Debug\SpeedrunComSharp.xml</DocumentationFile>
+    <NoWarn>1591</NoWarn>
   </PropertyGroup>
   <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Release|AnyCPU' ">
     <DebugType>pdbonly</DebugType>

--- a/SpeedrunComSharp/Users/UsersClient.cs
+++ b/SpeedrunComSharp/Users/UsersClient.cs
@@ -20,6 +20,11 @@ namespace SpeedrunComSharp
             return SpeedrunComClient.GetAPIUri(string.Format("{0}{1}", Name, subUri));
         }
 
+        /// <summary>
+        /// Fetch a User object identified by its URI.
+        /// </summary>
+        /// <param name="siteUri">The site URI for the user.</param>
+        /// <returns></returns>
         public User GetUserFromSiteUri(string siteUri)
         {
             var id = GetUserIDFromSiteUri(siteUri);
@@ -30,6 +35,11 @@ namespace SpeedrunComSharp
             return GetUser(id);
         }
 
+        /// <summary>
+        /// Fetch a User ID identified by its URI.
+        /// </summary>
+        /// <param name="siteUri">The site URI for the user.</param>
+        /// <returns></returns>
         public string GetUserIDFromSiteUri(string siteUri)
         {
             var elementDescription = baseClient.GetElementDescriptionFromSiteUri(siteUri);
@@ -41,6 +51,17 @@ namespace SpeedrunComSharp
             return elementDescription.ID;
         }
 
+        /// <summary>
+        /// Fetch a Collection of User objects identified by the parameters provided.
+        /// </summary>
+        /// <param name="name">Optional. If included, will filter users by their name.</param>
+        /// <param name="twitch">Optional. If included, will filter users by their linked Twitch account username.</param>
+        /// <param name="hitbox">Optional. If included, will filter users by their linked Hitbox account username.</param>
+        /// <param name="twitter">Optional. If included, will filter users by their linked Twitter account username.></param>
+        /// <param name="speedrunslive">Optional. If included, will filter users by their linked SpeedrunsLive account username.</param>
+        /// <param name="elementsPerPage">Optional. If included, will dictate the amount of elements included in each pagination.</param>
+        /// <param name="orderBy">Optional. If omitted, users will be in the same order as the API.</param>
+        /// <returns></returns>
         public IEnumerable<User> GetUsers(
             string name = null, 
             string twitch = null, string hitbox = null, 
@@ -80,6 +101,13 @@ namespace SpeedrunComSharp
                 x => User.Parse(baseClient, x) as User);
         }
 
+        /// <summary>
+        /// Fetch a Collection of User objects identified by their fuzzy (vague) username.
+        /// </summary>
+        /// <param name="fuzzyName">Optional. If included, dictates the fuzzy name of the user.</param>
+        /// <param name="elementsPerPage">Optional. If included, will dictate the amount of elements included in each pagination.</param>
+        /// <param name="orderBy">Optional. If omitted, users will be in the same order as the API.</param>
+        /// <returns></returns>
         public IEnumerable<User> GetUsersFuzzy(
             string fuzzyName = null,
             int? elementsPerPage = null,
@@ -101,6 +129,11 @@ namespace SpeedrunComSharp
                 x => User.Parse(baseClient, x) as User);
         }
 
+        /// <summary>
+        /// Fetch a User object identified by its ID.
+        /// </summary>
+        /// <param name="userId">The ID of the user.</param>
+        /// <returns></returns>
         public User GetUser(string userId)
         {
             var uri = GetUsersUri(string.Format("/{0}",
@@ -111,6 +144,15 @@ namespace SpeedrunComSharp
             return User.Parse(baseClient, result.data);
         }
 
+        /// <summary>
+        /// Fetch a Collection of Record objects of a user's personal bests identified by their ID.
+        /// </summary>
+        /// <param name="userId">The ID of the user.</param>
+        /// <param name="top">Optional. If included, will dictate the amount of top runs included in the response.</param>
+        /// <param name="seriesId">Optional. If included, will filter runs by their targetted game's series ID.</param>
+        /// <param name="gameId">Optional. If included, will filter runs by their targetted game's ID.</param>
+        /// <param name="embeds">Optional. If included, will dictate the additional resources embedded in the response.</param>
+        /// <returns></returns>
         public ReadOnlyCollection<Record> GetPersonalBests(
             string userId, int? top = null,
             string seriesId = null, string gameId = null,

--- a/SpeedrunComSharp/Users/UsersOrdering.cs
+++ b/SpeedrunComSharp/Users/UsersOrdering.cs
@@ -2,6 +2,9 @@
 
 namespace SpeedrunComSharp
 {
+    /// <summary>
+    /// Options for ordering Users in responses.
+    /// </summary>
     public enum UsersOrdering : int
     {
         Name = 0,

--- a/SpeedrunComSharp/Variables/VariablesClient.cs
+++ b/SpeedrunComSharp/Variables/VariablesClient.cs
@@ -18,6 +18,11 @@ namespace SpeedrunComSharp
             return SpeedrunComClient.GetAPIUri(string.Format("{0}{1}", Name, subUri));
         }
 
+        /// <summary>
+        /// Fetch a Variable object identified by its URI.
+        /// </summary>
+        /// <param name="siteUri">The site URI of the variable.</param>
+        /// <returns></returns>
         public Variable GetVariableFromSiteUri(string siteUri)
         {
             var id = GetVariableIDFromSiteUri(siteUri);
@@ -28,6 +33,11 @@ namespace SpeedrunComSharp
             return GetVariable(id);
         }
 
+        /// <summary>
+        /// Fetch a Variable ID identified by its URI.
+        /// </summary>
+        /// <param name="siteUri">The site URI of the variable.</param>
+        /// <returns></returns>
         public string GetVariableIDFromSiteUri(string siteUri)
         {
             var elementDescription = baseClient.GetElementDescriptionFromSiteUri(siteUri);
@@ -39,6 +49,11 @@ namespace SpeedrunComSharp
             return elementDescription.ID;
         }
 
+        /// <summary>
+        /// Fetch a Variable object identified by its ID.
+        /// </summary>
+        /// <param name="variableId">The ID of the variable.</param>
+        /// <returns></returns>
         public Variable GetVariable(string variableId)
         {
             var uri = GetVariablesUri(string.Format("/{0}",

--- a/SpeedrunComSharp/Variables/VariablesOrdering.cs
+++ b/SpeedrunComSharp/Variables/VariablesOrdering.cs
@@ -2,6 +2,9 @@
 
 namespace SpeedrunComSharp
 {
+    /// <summary>
+    /// Options for ordering Variables in responses.
+    /// </summary>
     public enum VariablesOrdering : int
     {
         Position = 0,


### PR DESCRIPTION
This PR adds documentation to most methods accessed by library users, as well as several structs and enums, specifically Ordering and Embedding, via [C# XML documentation comments](https://docs.microsoft.com/en-us/dotnet/csharp/language-reference/xmldoc/). This allows developers to see an overview of the methods and objects they're using, as well as the descriptions for the parameters being provided. This information is displayed automatically through the IDE, primarily through IntelliSense, as seen below.
![image](https://user-images.githubusercontent.com/68174586/144104733-8fb2c366-231d-47dd-bb5c-7a3c33c83da7.png)
