### PR TITLE
Match new speedrun.com run URLs

### DIFF
--- a/SpeedrunComSharp/Runs/RunsClient.cs
+++ b/SpeedrunComSharp/Runs/RunsClient.cs
@@ -47,7 +47,7 @@ namespace SpeedrunComSharp
         {
             try
             {
-                var match = Regex.Match(siteUri, "^(?:(?:https?://)?(?:www\\.)?speedrun\\.com/(?:\\w+/)?run/)?(\\w+)$");
+                var match = Regex.Match(siteUri, "^(?:(?:https?://)?(?:www\\.)?speedrun\\.com/(?:\\w+/)?runs?/)?(\\w+)$");
 
                 return match.Groups[1].Value;
             }


### PR DESCRIPTION
This closes #26.

Old URLs are still matched with this change.