### PR TITLE
Revert "Remove unnecessary `OutDir` property"

### DIFF
--- a/src/SpeedrunComSharp/SpeedrunComSharp.csproj
+++ b/src/SpeedrunComSharp/SpeedrunComSharp.csproj
@@ -1,5 +1,9 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
+  <PropertyGroup>
+    <OutDir>bin\$(Configuration)</OutDir>
+  </PropertyGroup>
+
   <ItemGroup>
     <Reference Include="Microsoft.CSharp" />
     <Reference Include="System.Web" />


### PR DESCRIPTION
Reverts LiveSplit/SpeedrunComSharp#32

The parent PR (https://github.com/LiveSplit/LiveSplit/pull/2484) isn't ready to be merged yet.