### PR TITLE
Add precision information to RunTimes

### DIFF
--- a/src/SpeedrunComSharp/Runs/RunTimes.cs
+++ b/src/SpeedrunComSharp/Runs/RunTimes.cs
@@ -2,12 +2,35 @@
 
 namespace SpeedrunComSharp;
 
+public struct RunTimeInformation
+{
+    public TimeSpan Time;
+    public bool HasSubseconds; // Indicator whether the leaderboard shows milliseconds
+
+    public RunTimeInformation(string isoRunTime, double numericRunTime)
+    {
+        Time = TimeSpan.FromSeconds(numericRunTime);
+        HasSubseconds = isoRunTime.Contains(".");
+    }
+
+    public static implicit operator TimeSpan(RunTimeInformation instance)
+    {
+        // For backwards compatibility return the time if queried for a TimeSpan
+        return instance.Time;
+    }
+
+    public override string ToString()
+    {
+        return Time.ToString();
+    }
+}
+
 public class RunTimes
 {
-    public TimeSpan? Primary { get; private set; }
-    public TimeSpan? RealTime { get; private set; }
-    public TimeSpan? RealTimeWithoutLoads { get; private set; }
-    public TimeSpan? GameTime { get; private set; }
+    public RunTimeInformation? Primary { get; private set; }
+    public RunTimeInformation? RealTime { get; private set; }
+    public RunTimeInformation? RealTimeWithoutLoads { get; private set; }
+    public RunTimeInformation? GameTime { get; private set; }
 
     private RunTimes() { }
 
@@ -17,22 +40,22 @@ public class RunTimes
 
         if (timesElement.primary != null)
         {
-            times.Primary = TimeSpan.FromSeconds((double)timesElement.primary_t);
+            times.Primary = new RunTimeInformation((string)timesElement.primary, (double)timesElement.primary_t);
         }
 
         if (timesElement.realtime != null)
         {
-            times.RealTime = TimeSpan.FromSeconds((double)timesElement.realtime_t);
+            times.RealTime = new RunTimeInformation((string)timesElement.realtime, (double)timesElement.realtime_t);
         }
 
         if (timesElement.realtime_noloads != null)
         {
-            times.RealTimeWithoutLoads = TimeSpan.FromSeconds((double)timesElement.realtime_noloads_t);
+            times.RealTimeWithoutLoads = new RunTimeInformation((string)timesElement.realtime_noloads, (double)timesElement.realtime_noloads_t);
         }
 
         if (timesElement.ingame != null)
         {
-            times.GameTime = TimeSpan.FromSeconds((double)timesElement.ingame_t);
+            times.GameTime = new RunTimeInformation((string)timesElement.ingame, (double)timesElement.ingame_t);
         }
 
         return times;
@@ -43,7 +66,7 @@ public class RunTimes
     {
         if (Primary.HasValue)
         {
-            return Primary.Value.ToString();
+            return Primary.Value.Time.ToString();
         }
         else
         {


### PR DESCRIPTION
Prepwork for WR component update.

Should be backwards compatible

From what I've seen, the SRC API return decimal point only when the corresponding leaderboard also shows milliseconds.

Taking the string ISO duration to determine if milliseconds are shown, but continue using the double entry to get the run time.

I didn't find a leaderboard with milliseconds with an entry of .000 so I don't know what the API would send in that case.